### PR TITLE
Update ca.json to change "Escriptura" with "Redacció". Adding translators info.

### DIFF
--- a/translations/ca.json
+++ b/translations/ca.json
@@ -5,18 +5,18 @@
         "translators": [
             {
                 "firstName": "Jordi",
-                "lastName": "Lacruz",
+                "lastName": "Lacruz Casado",
                 "middleName": "",
-                "ORCID": ""
+                "ORCID": "0000-0002-5053-6941"
             },
             {
                 "firstName": "Marc",
-                "lastName": "Bria",
-                "middleName": "",
-                "ORCID": ""
+                "lastName": "Bria Ramirez",
+                "middleName": "Roger",
+                "ORCID": "0000-0001-8485-8941"
             }
         ],
-        "translationProcedure": "The translators worked together to make this first translation. A second round of review was also done."
+        "translationProcedure": "The translators worked together to make this first translation. A second round of review was also done. Translation was finally presented to Editors to get feedback. Final ajustment was done."
     },
     "translations": {
         "https:\/\/credit.niso.org\/contributor-roles\/conceptualization\/": {
@@ -68,11 +68,11 @@
             "description": "Preparació, creació i\/o presentació del treball publicat, específicament la visualització i la presentació de dades."
         },
         "https:\/\/credit.niso.org\/contributor-roles\/writing-original-draft\/": {
-            "name": "Escriptura - esborrany original",
+            "name": "Redacció - esborrany original",
             "description": "Preparació, creació i\/o presentació del treball publicat, específicament la redacció de l'esborrany inicial (incloent-hi la traducció si és substancial)."
         },
         "https:\/\/credit.niso.org\/contributor-roles\/writing-review-editing\/": {
-            "name": "Escriptura - revisió i edició",
+            "name": "Redacció - revisió i edició",
             "description": "Preparació, creació i\/o presentació del treball publicat per part dels membres del grup de recerca original, concretament la revisió crítica, el debat o la revisió, incloent-hi les fases prèvies o posteriors a la publicació."
         }
     }


### PR DESCRIPTION
"Escriptura" is right but sounds kind of forced.

As in the Spanish translation, we asked catalan native Editorial fellows and they felt "Redacció" fits better with the task. Notice the explanation of the task talks about "redacció", so is better keeping the match between the title and the description (as we do in English).

Translators info was updated.